### PR TITLE
CloudObjectsDataPipeline

### DIFF
--- a/ava.config.cjs
+++ b/ava.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  timeout: '180s',
+  files: ['src/__tests__/*.test.ts'],
+  extensions: ['ts', 'js'],
+  require: ['ts-node/register', 'tsconfig-paths/register'],
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "ava",
         "build": "tsc -b",
         "prepare": "npm run build"
     },
@@ -16,11 +16,18 @@
     "author": "Retter",
     "license": "ISC",
     "dependencies": {
-        "axios": "0.26.0"
+        "axios": "0.26.0",
+        "lodash": "4.17.21"
     },
     "devDependencies": {
+        "@types/lodash": "4.14.182",
         "@types/node": "17.0.7",
+        "@types/sinon": "^10.0.12",
+        "ava": "4.3.1",
         "aws-sdk": "2.1048.0",
+        "sinon": "12.0.1",
+        "ts-node": "10.8.2",
+        "tsconfig-paths": "4.0.0",
         "typescript": "4.1.3"
     }
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,123 @@
+import test from 'ava'
+import sinon from 'sinon'
+import _ from 'lodash'
+import RDK, { OperationsOutput, OperationsInput } from '../index'
+
+const rdk = new RDK()
+
+test.beforeEach(() => {})
+
+const fakeInvokeLambda = async (payload: OperationsInput): Promise<OperationsOutput> => {
+  const res = {} as OperationsOutput
+  
+  for (const [key, value] of Object.entries(payload)) {
+    if (!res[key]) res[key] = []
+
+    value.forEach(() => {
+      res[key].push({
+        success: true,
+        data: "dummy"
+      })
+    })
+  }
+
+  return res
+}
+
+test.serial('dataPipeline chunk consuming test', async (t) => {
+  const pipeline = rdk.dataPipeline()
+  
+  for (let i = 0; i < 50; i++) {
+    pipeline.writeToDatabase({
+      partKey: 'partKey',
+      sortKey: 'sortKey',
+      data: {i}
+    })
+  }
+
+  for (let i = 0; i < 100; i++) {
+    pipeline.readDatabase({
+      partKey: 'partKey',
+      sortKey: 'sortKey',
+    })
+  }
+
+  // test generation of chunks
+  const chunks = pipeline.generateChunks(pipeline.payload)
+  t.is(chunks.writeToDatabase?.length, 2)
+  t.is(chunks.readDatabase?.length, 1)
+
+
+  const payload: OperationsInput = pipeline.consumeChunk(chunks)
+  // generated payload
+  t.is(payload.writeToDatabase?.length, 25)
+  t.is(payload.readDatabase?.length, 100)
+
+  // are chunks consumed?
+  t.is(chunks.writeToDatabase?.length, 1)
+  t.is(chunks.readDatabase?.length, 0)
+
+
+  const nextpayload: OperationsInput = pipeline.consumeChunk(chunks)
+  // generated payload
+  t.is(nextpayload.writeToDatabase?.length, 25)
+  t.is(nextpayload.readDatabase?.length, undefined)
+
+  // are chunks consumed?
+  t.is(chunks.writeToDatabase?.length, 0)
+  t.is(chunks.readDatabase?.length, 0)
+})
+
+test.serial('dataPipeline response combining test', async (t) => {
+  const pipeline = rdk.dataPipeline()
+
+  sinon.stub(pipeline, 'send').callsFake(async (): Promise<OperationsOutput> => {
+    const allRes: OperationsOutput = {} as OperationsOutput 
+
+    // payload now can hold many operations so lets split them into chucks
+    const chunks = pipeline.generateChunks(pipeline.payload)   
+
+    t.is(chunks.writeToDatabase?.length, 2)
+    t.is(chunks.readDatabase?.length, 1)
+
+    // do this until all chucks are prosessed
+    while (Object.values(chunks).some((v) => v.length > 0)) {
+        
+        const payload: OperationsInput = pipeline.consumeChunk(chunks)
+
+        // send the operations
+
+        const curRes = await fakeInvokeLambda(payload)
+
+        // combine the responses
+        _.mergeWith(allRes, curRes, (val1: OperationsOutput[], val2: OperationsOutput[]) => val1 ? val1.concat(val2) : val2)
+    } 
+
+    pipeline.payload = {}
+
+    t.is(allRes.writeToDatabase?.length, 50)
+    t.is(allRes.readDatabase?.length, 100)
+
+    return allRes
+  })
+  
+  for (let i = 0; i < 50; i++) {
+    pipeline.writeToDatabase({
+      partKey: 'partKey',
+      sortKey: 'sortKey',
+      data: {i}
+    })
+  }
+
+  for (let i = 0; i < 100; i++) {
+    pipeline.readDatabase({
+      partKey: 'partKey',
+      sortKey: 'sortKey',
+    })
+  }
+
+  pipeline.send()
+  
+  t.pass()
+})
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,7 +373,7 @@ export interface OperationsOutput extends ReadonlyOperationsOutput {
     deployClass?: OperationResponse[]
     invalidateCache?: InvalidateCacheResponse[]
 }
-export interface ChuckedOperations {
+export interface ChunkedOperations {
     writeToDatabase?: WriteToDatabase[][]
     readDatabase?: ReadDatabase[][]
     removeFromDatabase?: RemoveFromDatabase[][]
@@ -1232,8 +1232,8 @@ export class CloudObjectsDataPipeline extends CloudObjectsPipeline {
         return 0
     }
 
-    generateChunks(payload: OperationsInput): ChuckedOperations {
-        const chunks: ChuckedOperations = {}
+    generateChunks(payload: OperationsInput): ChunkedOperations {
+        const chunks: ChunkedOperations = {}
 
         // seperate to chucks by operation
         for (const [key, value] of Object.entries(payload)) {
@@ -1253,7 +1253,7 @@ export class CloudObjectsDataPipeline extends CloudObjectsPipeline {
     }
 
     // generate default payload for a normal pipeline from 1 chunk of each operation
-    consumeChunk(chunks: ChuckedOperations): OperationsInput {
+    consumeChunk(chunks: ChunkedOperations): OperationsInput {
         const payload: OperationsInput = {}
         for (const [key, value] of Object.entries(chunks)) {
             if (!value.length) continue

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,7 @@ export function init(c: any, t: string, o: string, ocLimit?: number, clcLimit?: 
 function calculateSize(data: string) {
     return new TextEncoder().encode(data).length
 }
-export async function invokeLambda(payload: OperationsInput): Promise<OperationsOutput> {
+async function invokeLambda(payload: OperationsInput): Promise<OperationsOutput> {
 
     if (concurrentLambdaCount > concurrentLambdaCountLimit) {
         throw new Error(`Cannot send more than ${concurrentLambdaCountLimit} operations without pipeline`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1282,7 +1282,7 @@ export class CloudObjectsDataPipeline extends CloudObjectsPipeline {
             const curRes = await invokeLambda(payload)
 
             // combine the responses
-            _.mergeWith(allRes, curRes, (val1: OperationsOutput[], val2: OperationsOutput[]) => val1.concat(val2))
+            _.mergeWith(allRes, curRes, (val1: OperationsOutput[], val2: OperationsOutput[]) => val1 ? val1.concat(val2) : val2)
         } 
 
         this.payload = {}


### PR DESCRIPTION
for an example lets assume user has to insterted following operations to pipeline:
    -> 100 writeToDatabase operations
    -> 300 readDatabase operations

    normally user cant send all these operations in one request,
    we have limits by operation type
    -> for example:
            * writetoDatabase limit 25
            * readDatabase limit 100
            
    "CloudObjectsDataPipeline" can handle this situation without any extra code on usercode side

    this is how: 
    1. we will seperate the operations into chunks by allowed limits for each operation:
        -> for example situation above we will have following chunks:
            *  4 chunks for writeToDatabase
            *  3 chunks for readDatabase
        
    2. generate default payload for a normal pipeline from these chunks
        * consume 1 chunk from each operation
    
    3. send this payload just like a normal pipeline
    
    3. do this until no chunks are left:
        -> for example situation above we will have to do this 4 times
        -> 1. invoke lambda 25 writetoDatabase, 100 readDatabase
        -> 2. invoke lambda 25 writetoDatabase, 100 readDatabase
        -> 3. invoke lambda 25 writetoDatabase, 100 readDatabase
        -> 4. invoke lambda 25 writetoDatabase,

    4. combine the responses from the chunks and return the final response